### PR TITLE
Changed regular expressions to not require a new line before the match.

### DIFF
--- a/paramikoe.py
+++ b/paramikoe.py
@@ -114,7 +114,7 @@ class SSHClientInteraction:
             len(re_strings) == 0 or
             not [re_string
                  for re_string in re_strings
-                 if re.match('.*\n' + re_string + '$',
+                 if re.match(re_string + '$',
                              self.current_output, re.DOTALL)]
         ):
 
@@ -142,7 +142,7 @@ class SSHClientInteraction:
         if len(re_strings) != 0:
             found_pattern = [(re_index, re_string)
                              for re_index, re_string in enumerate(re_strings)
-                             if re.match('.*\n' + re_string + '$',
+                             if re.match(re_string + '$',
                                          self.current_output, re.DOTALL)]
 
         self.current_output_clean = self.current_output


### PR DESCRIPTION
I was having trouble with some hosts that would give a logon prompt on the first line after logging in.  I changed the regular expression being used so this wasn't required.

For example this was an issue when trying to connect to Arista switches without a banner or motd that the user hadn't logged onto since the last reboot/upgrade.
Example:
[skoog@host ~]$ ssh skoog@labarista
password:
labarista>
