### PR TITLE
Allow send() to skip appending newline at the end.

### DIFF
--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -200,10 +200,13 @@ class SSHClientInteraction(object):
             # measure, let's send back a -1
             return -1
 
-    def send(self, send_string):
+    def send(self, send_string, newline=True):
         """Saves and sends the send string provided."""
         self.current_send_string = send_string
-        self.channel.send(send_string + self.newline)
+        if newline:
+            self.channel.send(send_string + self.newline)
+        else:
+            self.channel.send(send_string)
 
     def tail(self, line_prefix=None, callback=None, output_callback=None, stop_callback=lambda x: False, timeout=None):
         """

--- a/test/test_paramiko_expect.py
+++ b/test/test_paramiko_expect.py
@@ -56,6 +56,9 @@ def test_02_test_other_commnads(interact):
     interact.send('ls -l /')
     interact.expect(prompt, timeout=5)
 
+    # Do not actually sleep, send a ctrl-c at the end
+    interact.send('sleep 3600' + chr(3), newline=False)
+
 def test_03_test_demo_helper(interact):
     interact.expect(prompt)
     interact.send('python /examples/paramiko_expect-demo-helper.py')


### PR DESCRIPTION
Sometimes, you only want to send a control character (Ctrl-C) without a newline.

This PR adds a new optional `newline` boolean parameter to the `send()` method to override the default behavior.