### PR TITLE
Use more lines to check for prompt at the end of the output

### DIFF
--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -25,9 +25,11 @@ try:
     import termios
     import tty
     has_termios = True
+    MAX_TIMEOUT = 2 ** (struct.Struct(str('i')).size * 8 - 1) - 1
 except ImportError:  # pragma: no cover
     import threading
     has_termios = False
+    MAX_TIMEOUT = threading.TIMEOUT_MAX
 
 import select
 
@@ -272,10 +274,10 @@ class SSHClientInteraction(object):
 
         output_callback = output_callback if output_callback else self.output_callback
 
-        # Set the channel timeout to the maximum value the threading package allows,
+        # Set the channel timeout to the maximum allowed value,
         # setting this to None breaks the KeyboardInterrupt exception and
-        # won't allow us to Ctrl+C out of teh script
-        timeout = timeout if timeout else threading.TIMEOUT_MAX
+        # won't allow us to Ctrl+C out of the script
+        timeout = timeout if timeout else MAX_TIMEOUT
         self.channel.settimeout(timeout)
 
         # Create an empty line buffer and a line counter

--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -56,12 +56,14 @@ class SSHClientInteraction(object):
                     real-time as it is being performed (especially useful
                     when debugging)
     :param encoding: The character encoding to use.
+    :param lines_to_check: The number of last few lines of the output to
+                           look at, while matching regular expression(s)
     """
 
     def __init__(
         self, client, timeout=60, newline='\r', buffer_size=1024,
         display=False, encoding='utf-8', output_callback=default_output_func,
-        tty_width=80, tty_height=24
+        tty_width=80, tty_height=24, lines_to_check=2
     ):
         self.channel = client.invoke_shell(width=tty_width, height=tty_height)
         self.timeout = timeout
@@ -70,6 +72,7 @@ class SSHClientInteraction(object):
         self.display = display
         self.encoding = encoding
         self.output_callback = output_callback
+        self.lines_to_check = lines_to_check
 
         self.current_output = ''
         self.current_output_clean = ''
@@ -98,7 +101,7 @@ class SSHClientInteraction(object):
 
     def expect(
         self, re_strings='', timeout=None, output_callback=None, default_match_prefix='.*\n',
-        strip_ansi=True, ignore_decode_error=True
+        strip_ansi=True, ignore_decode_error=True, lines_to_check=None
     ):
         """
         This function takes in a regular expression (or regular expressions)
@@ -124,6 +127,8 @@ class SSHClientInteraction(object):
                            default to True.
         :param ignore_decode_error: If True, will ignore decode errors if any.
                            default to True.
+        :param lines_to_check: The number of last few lines of the output to
+                               look at, while matching regular expression(s)
         :return: An EOF returns -1, a regex metch returns 0 and a match in a
                  list of regexes returns the index of the matched string in
                  the list.
@@ -134,6 +139,8 @@ class SSHClientInteraction(object):
         # Set the channel timeout
         timeout = timeout if timeout else self.timeout
         self.channel.settimeout(timeout)
+
+        lines_to_check = lines_to_check if lines_to_check else self.lines_to_check
 
         if ignore_decode_error:
             self.decoder = codecs.getincrementaldecoder(self.encoding)('ignore')
@@ -188,7 +195,7 @@ class SSHClientInteraction(object):
 
             # Add the currently read buffer to the output
             self.current_output += current_buffer_decoded
-            current_buffer_output_decoded = '\n' + self.current_output.splitlines()[-1]
+            current_buffer_output_decoded = '\n' + '\n'.join(self.current_output.splitlines()[-lines_to_check:])
 
         # Grab the first pattern that was matched
         if len(re_strings) != 0:

--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -65,7 +65,7 @@ class SSHClientInteraction(object):
     def __init__(
         self, client, timeout=60, newline='\r', buffer_size=1024,
         display=False, encoding='utf-8', output_callback=default_output_func,
-        tty_width=80, tty_height=24, lines_to_check=2
+        tty_width=80, tty_height=24, lines_to_check=1
     ):
         self.channel = client.invoke_shell(width=tty_width, height=tty_height)
         self.timeout = timeout

--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -272,10 +272,10 @@ class SSHClientInteraction(object):
 
         output_callback = output_callback if output_callback else self.output_callback
 
-        # Set the channel timeout to the maximum integer the server allows,
+        # Set the channel timeout to the maximum value the threading package allows,
         # setting this to None breaks the KeyboardInterrupt exception and
         # won't allow us to Ctrl+C out of teh script
-        timeout = timeout if timeout else 2 ** (struct.Struct(str('i')).size * 8 - 1) - 1
+        timeout = timeout if timeout else threading.TIMEOUT_MAX
         self.channel.settimeout(timeout)
 
         # Create an empty line buffer and a line counter


### PR DESCRIPTION
In our project our Bash prompt is modded to look similar to ksh like:

> hostname:/current/directory
> $

So the prompt makes up last two lines. This enhancement will allow more than just the last line while looking for the prompt.