### PR TITLE
Fix 'OverflowError: timeout value is too large' in tail method

### DIFF
--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -25,9 +25,11 @@ try:
     import termios
     import tty
     has_termios = True
+    MAX_TIMEOUT = 2 ** (struct.Struct(str('i')).size * 8 - 1) - 1
 except ImportError:  # pragma: no cover
     import threading
     has_termios = False
+    MAX_TIMEOUT = threading.TIMEOUT_MAX
 
 import select
 
@@ -265,10 +267,10 @@ class SSHClientInteraction(object):
 
         output_callback = output_callback if output_callback else self.output_callback
 
-        # Set the channel timeout to the maximum value the threading package allows,
+        # Set the channel timeout to the maximum allowed value,
         # setting this to None breaks the KeyboardInterrupt exception and
-        # won't allow us to Ctrl+C out of teh script
-        timeout = timeout if timeout else threading.TIMEOUT_MAX
+        # won't allow us to Ctrl+C out of the script
+        timeout = timeout if timeout else MAX_TIMEOUT
         self.channel.settimeout(timeout)
 
         # Create an empty line buffer and a line counter

--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -265,10 +265,10 @@ class SSHClientInteraction(object):
 
         output_callback = output_callback if output_callback else self.output_callback
 
-        # Set the channel timeout to the maximum integer the server allows,
+        # Set the channel timeout to the maximum value the threading package allows,
         # setting this to None breaks the KeyboardInterrupt exception and
         # won't allow us to Ctrl+C out of teh script
-        timeout = timeout if timeout else 2 ** (struct.Struct(str('i')).size * 8 - 1) - 1
+        timeout = timeout if timeout else threading.TIMEOUT_MAX
         self.channel.settimeout(timeout)
 
         # Create an empty line buffer and a line counter


### PR DESCRIPTION
Hello, if I leave `timeout==None` in `tail()` method, the execution fails with

```
[...]
  File "C:\workspace\partec\remote-tail-f\venv\lib\site-packages\paramiko_expect.py", line 283, in tail
    buffer = self.channel.recv(1)
  File "C:\workspace\partec\remote-tail-f\venv\lib\site-packages\paramiko\channel.py", line 699, in recv
    out = self.in_buffer.read(nbytes, self.timeout)
  File "C:\workspace\partec\remote-tail-f\venv\lib\site-packages\paramiko\buffered_pipe.py", line 160, in read
    self._cv.wait(timeout)
  File "C:\Users\simone.rossetto\AppData\Local\Programs\Python\Python39\lib\threading.py", line 316, in wait
    gotit = waiter.acquire(True, timeout)
OverflowError: timeout value is too large
```

Using `threading.TIMEOUT_MAX` as None (max) timeout value fixes the error.