### PR TITLE
Fix encoding issue of test on python 2.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         sudo chown `whoami` `pwd`/test/id_rsa.pub
         docker run -d -p 2222:22 -v `pwd`/examples:/examples -v `pwd`/test/id_rsa.pub:/root/.ssh/authorized_keys -e SSH_ENABLE_ROOT=true docker.io/panubo/sshd
         sleep 2
-        py.test -s --cov paramiko_expect --cov-report term-missing
+        PYTHONIOENCODING=utf-8 py.test -s --cov paramiko_expect --cov-report term-missing
     - name: Upload coverage.xml to codecov
       if: ${{ matrix.python-version == '3.8' }}
       uses: codecov/codecov-action@v1

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author_email='fgimiansoftware@gmail.com',
     description='An expect-like extension for the Paramiko SSH library',
     long_description=long_description,
+    long_description_content_type='text/x-rst'
     platforms='Posix',
     py_modules=['paramiko_expect'],
     install_requires=[

--- a/test/test_paramiko_expect.py
+++ b/test/test_paramiko_expect.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import socket
 
 import pytest
@@ -238,3 +240,6 @@ def test_08_issue_25_skip_newline():
 
         interact.send('ls -all')
         interact.expect(prompt, timeout=5)
+
+def test_09_utf8(interact):
+    interact.send(u'André')


### PR DESCRIPTION
test were failing cause of the lack of encoding on the default output function

```
    def default_output_func(msg):
>       sys.stdout.write(msg)
E       UnicodeEncodeError: 'ascii' codec can't encode characters in position 13-27: ordinal not in range(128)
```