### PR TITLE
Strip ANSI CSI codes from xterm output

### DIFF
--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -35,7 +35,7 @@ import select
 
 
 def strip_ansi_codes(s):
-    return re.sub(r'\x1b\[([0-9,A-Z]{1,2}(;[0-9]{1,2})?(;[0-9]{3})?)?[m|K]?', '', s)
+    return re.sub(r'\x1b\[([0-9,A-Z]{1,2}(;[0-9]{1,2})?(;[0-9]{3})?)?[m|K]?|\?(1049|2004)[hl]', '', s)
 
 
 def default_output_func(msg):


### PR DESCRIPTION
On my linux box the display from *expect()* always prints `ESC[?2004h` or `ESC[?2004l` before the prompt and that brakes the *expect()* itself. On the web I found that those codes could be xterm CSI codes (see [wiki](https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences)) so I changed the regex in `strip_ansi_codes()` to handle them.