### PR TITLE
Issue #84 - Apply timeout removal on Windows when going interactive

### DIFF
--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -368,6 +368,10 @@ class SSHClientInteraction(object):
                 # Restore the attributes of the shell you were in
                 termios.tcsetattr(sys.stdin, termios.TCSADRAIN, original_tty)
         else:
+            # We must set the timeout to None so that we can bypass times when
+            # there is no available text to receive
+            self.channel.settimeout(None)
+
             def writeall(sock):
                 while True:
                     buffer = sock.recv(self.buffer_size)


### PR DESCRIPTION
After [looking at threading code, it seems that `None` is the value that should work for both Windows and Linux](https://github.com/python/cpython/blob/3.10/Lib/threading.py#L319), but I am only adding it for the Windows case to make sure nothing else breaks.

This fixes #84 (tested on my Windows 11 system).
