### PR TITLE
Check whether channel is closed...

### DIFF
--- a/paramiko_expect.py
+++ b/paramiko_expect.py
@@ -168,7 +168,7 @@ class SSHClientInteraction(object):
         ):
             current_buffer_output_decoded = ''
             # avoids paramiko hang when recv is not ready yet
-            while not self.channel.recv_ready():
+            while not self.channel.closed and not self.channel.recv_ready():
                 time.sleep(.009)
                 if time.time() >= (base_time + timeout):
                     print('EXCESS TIME RECV_READY TIMEOUT, did you expect() before a send()')


### PR DESCRIPTION
before checking `recv_ready()`, to avoid excess time RECV_READY timeout.

Some network routers send a message and close the channel after they receive an exit command. If you want to grab the exit message, you should check whether the channel is closed, and if so, read the resting bytes in the closed channel other than waiting for `self.channel. recv_ready()` (which is always `False` on a closed channel) and timing out.

See #87